### PR TITLE
refactor: use process.hrtime.bigint

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@commitlint/config-conventional": "latest",
     "ava": "latest",
     "c8": "latest",
-    "cacheable-lookup": "latest",
+    "cacheable-lookup": "6",
     "ci-publish": "latest",
     "conventional-github-releaser": "latest",
     "finepack": "latest",

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,8 @@ const loggerNoop = (() => {
   return debug
 })()
 
-const timestamp = (start = process.hrtime()) => () => {
-  const hrtime = process.hrtime(start)
-  const nanoseconds = hrtime[0] * 1e9 + hrtime[1]
-  return nanoseconds / 1e6
-}
+const timestamp = (start = process.hrtime.bigint()) => () =>
+  Number(process.hrtime.bigint() - start) / 1e6
 
 const createLogWithDuration = transport => (...args) => {
   const end = timestamp()


### PR DESCRIPTION
Since `process.hrtime` is a legacy API.